### PR TITLE
Update api.ts

### DIFF
--- a/src/actions/facebook/lib/api.ts
+++ b/src/actions/facebook/lib/api.ts
@@ -2,7 +2,7 @@ import * as gaxios from "gaxios"
 import * as winston from "winston"
 import {formatFullDate, isNullOrUndefined, sanitizeError, sortCompare} from "./util"
 
-export const API_VERSION = "v16.0"
+export const API_VERSION = "v19.0"
 export const API_BASE_URL = `https://graph.facebook.com/${API_VERSION}/`
 export const CUSTOMER_LIST_SOURCE_TYPES = {
     // Used by Facebook for unknown purposes.


### PR DESCRIPTION
Change Facebook Marketing API to version v19.0

The version API v16.0 is deprecated since 2023-02-06  (s. https://developers.facebook.com/docs/marketing-api/versions/). Therefore the action "Facebook Custom Audiences" is not working anymore since 2023-02-06.

I request the upgrade to v19.0 that is the actual version without a EOL date at the moment.
